### PR TITLE
Issue 19 and example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ ccon_delete_cluster(&clone_cluster);
 
 // custom cloned cluster
 ccon_node* my_own_node = ccon_create_default_node();
-ccon_cluster* my_own_clone_cluster = ccon_create_cluster_from_node(my_own_node, 5);
-int node_delete_result = ccon_delete_node(&my_own_node);
+ccon_cluster* my_own_clone_cluster = ccon_create_cluster_from_node(my_own_node, 5, 0);
 ccon_delete_cluster(&my_own_clone_cluster);
 
 // handrolled cluster (see node.h for further information on node creation).
@@ -132,7 +131,7 @@ or Docker. CMake assumes the library has been installed.
 
 ```bash
 # CMake testing
-cd tests
+cd test
 cmake -B build
 cmake --build build
 ctest --test-dir build

--- a/examples/simple-tcp/README.md
+++ b/examples/simple-tcp/README.md
@@ -5,3 +5,5 @@ This client creates X number of nodes (each with a server and client functionali
 To do this, a cluster is created with X nodes, each node has a serve function associated with it, and an action function.
 
 To undertake the chatter event, the server of each node is invoked, and then shortly after the action function (the sender) is invoked. The action of each node sends a shut off request to a different node.
+
+Note: the TCP code that this example relies on is very simple -> if a connection/send fails, the program will just exit (but that's not what's being showcased here...).

--- a/examples/simple-tcp/src/cluster_manager.c
+++ b/examples/simple-tcp/src/cluster_manager.c
@@ -40,7 +40,7 @@ cluster* generate_cluster(int node_count) {
         return NULL;
     }
 
-    ccon_cluster* inner_cluster = ccon_create_cluster_from_node(model_node, node_count);
+    ccon_cluster* inner_cluster = ccon_create_cluster_from_node(model_node, node_count, -1);
     if (inner_cluster != NULL) {
         ccon_delete_node(&model_node);
         
@@ -141,6 +141,7 @@ void* node_background_action(void* args) {
 
     if (result != 0) {
         printf("Failed to send kill message to the server.\n");
+        exit(-1);
     } else {
         printf("Sent kill message to the server.\n");
     }

--- a/include/cluster.h
+++ b/include/cluster.h
@@ -34,9 +34,12 @@ EXPORT ccon_cluster* ccon_create_cluster(ccon_node** nodes, int node_count);
  * 
  * @param node_struct ccon_node struct to clone, cannot be NULL
  * @param node_count number of nodes to create.
+ * @param include_node if 0, include node in the created cluster, else don't.
  * @return cluster* cluster struct or NULL.
  */
-EXPORT ccon_cluster* ccon_create_cluster_from_node(ccon_node* node_struct, int node_count);
+EXPORT ccon_cluster* ccon_create_cluster_from_node(ccon_node* node_struct,
+                                                   int node_count,
+                                                   int include_node);
 
 /**
  * @brief Create a cluster of population node_count from default ccon_node struct.

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -33,7 +33,9 @@ ccon_cluster* ccon_create_cluster(ccon_node** nodes, int node_count) {
     return cluster_struct;
 }
 
-ccon_cluster* ccon_create_cluster_from_node(ccon_node* node_struct, int node_count) {
+ccon_cluster* ccon_create_cluster_from_node(ccon_node* node_struct,
+                                            int node_count,
+                                            int include_node) {
     if (node_count < 1 || node_struct == NULL) {
         return NULL;
     }
@@ -43,10 +45,14 @@ ccon_cluster* ccon_create_cluster_from_node(ccon_node* node_struct, int node_cou
         return NULL;
     }
 
-    node_array[0] = ccon_copy_node(node_struct);
-    if (node_array[0] == NULL) {
-        free(node_array);
-        return NULL;
+    if (include_node == 0) {
+        node_array[0] = node_struct;
+    } else {
+        node_array[0] = ccon_copy_node(node_struct);
+        if (node_array[0] == NULL) {
+            free(node_array);
+            return NULL;
+        }
     }
     
     for (int i = 1; i < node_count; i++) {
@@ -77,8 +83,7 @@ ccon_cluster* ccon_create_cluster_from_default_node(int node_count) {
 
     ccon_node* default_node = ccon_create_default_node();
 
-    ccon_cluster* cluster_struct = ccon_create_cluster_from_node(default_node, node_count);
-    ccon_delete_node(&default_node);
+    ccon_cluster* cluster_struct = ccon_create_cluster_from_node(default_node, node_count, 0);
     if (cluster_struct == NULL) {
         return NULL;
     } else {

--- a/test/src/cluster_test.cc
+++ b/test/src/cluster_test.cc
@@ -237,11 +237,22 @@ TEST_F(ClusterTest, ClusterCreationAndDeletion) {
 
 TEST_F(ClusterTest, ClusterCreationFromNode) {
     ccon_node* node_struct = ccon_create_default_node();
-    ccon_cluster* cluster_struct = ccon_create_cluster_from_node(node_struct, 3);
+    ccon_cluster* cluster_struct = ccon_create_cluster_from_node(node_struct, 3, -1);
     ASSERT_NE(cluster_struct, nullptr);
     ASSERT_EQ(cluster_struct->node_count, 3);
 
     ccon_delete_node(&node_struct);
+
+    int result = ccon_delete_cluster(&cluster_struct);
+    ASSERT_EQ(result, 0);
+    ASSERT_EQ(cluster_struct, nullptr);
+}
+
+TEST_F(ClusterTest, ClusterInclusiveCreationFromNode) {
+    ccon_node* node_struct = ccon_create_default_node();
+    ccon_cluster* cluster_struct = ccon_create_cluster_from_node(node_struct, 3, 0);
+    ASSERT_NE(cluster_struct, nullptr);
+    ASSERT_EQ(cluster_struct->node_count, 3);
 
     int result = ccon_delete_cluster(&cluster_struct);
     ASSERT_EQ(result, 0);


### PR DESCRIPTION
This PR:
- adds a flag to ccon_create_cluster_from_node so that the passed in node can be included in the cluster if the client wishes
- updates the unit tests accordingly
- adds a line to the simpletcp example discussing the unreliability of the tcp connections.